### PR TITLE
Add mp4-to-mp3 recipe.

### DIFF
--- a/recipes/mp4/to-mp3/Makefile
+++ b/recipes/mp4/to-mp3/Makefile
@@ -1,0 +1,21 @@
+bitrate = 320k
+# ______________________________________________________________________________
+DIRMP4 = $(shell dir *.mp4)
+DIRMP3 = $(DIRMP4:.mp4=.mp3)
+
+all: clean Makefile $(DIRMP3)
+
+%.mp3: %.mp4
+	AV_LOG_FORCE_NOCOLOR=TRUE avconv -loglevel info -i "$<" -vn -ab $(bitrate) "$@"
+	echo "$@" >> provide
+
+clean:
+	rm -f *.mp3 provide
+
+install-tools:
+	sudo apt-get install avconv
+
+require:
+	@echo
+
+.PHONY: all install-tools require clean


### PR DESCRIPTION
Also, consider using `avconv` instead of `ffmpeg` in you recipes, `ffmpeg` is deprecated.

Also note the `NOCOLOR` trick, it makes the log in emacs' compilation buffer a lot more readable (unless I'm silly and haven't configured it properly, but I'd expect it not to be able to parse the term escapes).

Nice package by the way :)
