### PR TITLE
change ':' to '_' for temp directory so it works on windows

### DIFF
--- a/make-it-so.el
+++ b/make-it-so.el
@@ -379,7 +379,7 @@ Switch to other window afterwards."
          (basedir (or (file-name-directory source)
                       default-directory))
          (dir (expand-file-name
-               (format "%s:%s" x (file-name-nondirectory source))
+               (format "%s_%s" x (file-name-nondirectory source))
                basedir))
          (makefile-template
           (mis-build-path (mis-directory) ext x "Makefile"))


### PR DESCRIPTION
Hi, there seems to be a problem with using ":" in path names on windows.  I just replaced with an "_" for the staging directory name.  Hopefully that works.  Thanks!